### PR TITLE
feat: dynamic menus

### DIFF
--- a/src/layouts/default/sidebar/components/Menu.vue
+++ b/src/layouts/default/sidebar/components/Menu.vue
@@ -30,8 +30,8 @@ import { useRouteStore } from '~/stores'
 
 const { getCollapsed } = useCollapsed()
 
-const selectedKeys = ref(['1'])
-const openKeys = ref(['sub1'])
+const selectedKeys = ref<string[]>([])
+const openKeys = ref<string[]>([])
 
 const router = useRouter()
 const routeStore = useRouteStore()
@@ -44,6 +44,12 @@ const handleClick = (path: string) => {
 watch(() => routeStore.getRoutes, (routes) => {
   menus.value = routes
 }, { immediate: true })
+
+// 当路由发生改变时，这里的 selectedKeys 也要发生改变
+// 用于修复进入到不是菜单的路由时，这里的 selectedKeys 仍然是旧的问题
+watch(() => router.currentRoute.value, (currentRoute) => {
+  selectedKeys.value = [currentRoute.path]
+})
 
 // 当刷新页面时，设置菜单选中状态
 function setupCurrentMenu() {

--- a/src/layouts/default/sidebar/components/Menu.vue
+++ b/src/layouts/default/sidebar/components/Menu.vue
@@ -1,7 +1,7 @@
 <template>
   <a-menu
-    v-model:openKeys="openKeys" 
-    v-model:selectedKeys="selectedKeys" 
+    v-model:openKeys="openKeys"
+    v-model:selectedKeys="selectedKeys"
     mode="inline" theme="dark"
     :inline-collapsed="getCollapsed"
   >

--- a/src/layouts/default/sidebar/components/Menu.vue
+++ b/src/layouts/default/sidebar/components/Menu.vue
@@ -1,35 +1,29 @@
 <template>
   <a-menu
-    v-model:openKeys="openKeys"
-    v-model:selectedKeys="selectedKeys"
+    v-model:openKeys="openKeys" 
+    v-model:selectedKeys="selectedKeys" 
     mode="inline" theme="dark"
     :inline-collapsed="getCollapsed"
   >
     <template v-for="menu in menus" :key="menu.path">
-      <a-sub-menu v-if="!menu.meta?.single" :key="menu.path">
-        <template #icon>
-          <component :is="menu.meta?.icon" />
-        </template>
-        <template #title>
-          {{ menu.meta?.title }}
-        </template>
-        <a-menu-item
-          v-for="subMenu in menu.children" :key="menu.path + '/' + subMenu.path"
-          @click="handleClick(menu.path + '/' + subMenu.path)"
-        >
-          {{ subMenu.meta?.title }}
-        </a-menu-item>
-      </a-sub-menu>
-      <a-menu-item v-else @click="handleClick(menu.path)">
-        <template #icon>
-          <component :is="menu.meta?.icon" />
-        </template>
-        {{ menu.meta.title }}
-      </a-menu-item>
+      <menu-item
+        v-if="menu.meta?.single"
+        :menu="menu"
+        @handle-click="handleClick"
+      />
+      <menu-with-children
+        v-else
+        :current-depth="1"
+        :parent-path="menu.path"
+        :menu="menu"
+        @handle-click="handleClick"
+      />
     </template>
   </a-menu>
 </template>
 <script setup lang="ts">
+import MenuWithChildren from './MenuWithChildren.vue'
+import MenuItem from './MenuItem.vue'
 import { useCollapsed } from '~/layouts/default/useCollapsed'
 import type { RouteModuleList } from '~/router/routes/typings'
 import { useRouteStore } from '~/stores'

--- a/src/layouts/default/sidebar/components/Menu.vue
+++ b/src/layouts/default/sidebar/components/Menu.vue
@@ -1,6 +1,8 @@
 <template>
   <a-menu
-    v-model:openKeys="openKeys" v-model:selectedKeys="selectedKeys" mode="inline" theme="dark"
+    v-model:openKeys="openKeys"
+    v-model:selectedKeys="selectedKeys"
+    mode="inline" theme="dark"
     :inline-collapsed="getCollapsed"
   >
     <template v-for="menu in menus" :key="menu.path">

--- a/src/layouts/default/sidebar/components/Menu.vue
+++ b/src/layouts/default/sidebar/components/Menu.vue
@@ -52,13 +52,13 @@ watch(() => routeStore.getRoutes, (routes) => {
 }, { immediate: true })
 
 // 当刷新页面时，设置菜单选中状态
-function setSelectMenuWhenRefreshPage() {
+function setupCurrentMenu() {
   const currentRoute = router.currentRoute.value
   selectedKeys.value = getCurrentMenuRecursive(menus.value, currentRoute.path)
   openKeys.value = selectedKeys.value
 }
 
-setSelectMenuWhenRefreshPage()
+setupCurrentMenu()
 
 function getCurrentMenuRecursive(menus: RouteModuleList, targetKey: string, parentPath = '', parentMenus: GetArrayItemType<RouteModuleList>[] = []) {
   let keys: GetArrayItemType<RouteModuleList> = []

--- a/src/layouts/default/sidebar/components/MenuItem.vue
+++ b/src/layouts/default/sidebar/components/MenuItem.vue
@@ -1,0 +1,30 @@
+<template>
+  <a-menu-item
+    :key="parentPath ? `${parentPath}/${menu.path}` : menu.path"
+    @click="handleClick(menu.path)"
+  >
+    <template #icon>
+      <component :is="menu.meta?.icon" />
+    </template>
+    {{ menu.meta.title }}
+  </a-menu-item>
+</template>
+<script setup lang="ts">
+import type { RouteModuleList } from '~/router/routes/typings'
+
+interface EmitEvents {
+  (e: 'handleClick', path: string, currentDepth: number | undefined): void
+}
+interface Props {
+  menu: GetArrayItemType<RouteModuleList>
+  parentPath?: string
+  currentDepth?: number
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<EmitEvents>()
+
+function handleClick(path: string) {
+  emit('handleClick', path, props.currentDepth)
+}
+</script>

--- a/src/layouts/default/sidebar/components/MenuWithChildren.vue
+++ b/src/layouts/default/sidebar/components/MenuWithChildren.vue
@@ -6,8 +6,8 @@
     <template #title>
       {{ menu.meta?.title }}
     </template>
-    <template 
-      v-for="subMenu in menu.children" 
+    <template
+      v-for="subMenu in menu.children"
       :key="menu.path + '/' + subMenu.path"
     >
       <menu-with-children

--- a/src/layouts/default/sidebar/components/MenuWithChildren.vue
+++ b/src/layouts/default/sidebar/components/MenuWithChildren.vue
@@ -1,0 +1,49 @@
+<template>
+  <a-sub-menu :key="menu.path">
+    <template #icon>
+      <component :is="menu.meta?.icon" />
+    </template>
+    <template #title>
+      {{ menu.meta?.title }}
+    </template>
+    <template 
+      v-for="subMenu in menu.children" 
+      :key="menu.path + '/' + subMenu.path"
+    >
+      <menu-with-children
+        v-if="subMenu.children"
+        :parent-path="parentPath + '/' + subMenu.path"
+        :menu="subMenu"
+        :current-depth="currentDepth + 1"
+        @handle-click="handleClick"
+      />
+      <menu-item
+        v-else :menu="subMenu"
+        :parent-path="currentDepth > 1 ? parentPath : menu.path"
+        :current-depth="currentDepth + 1"
+        @handle-click="handleClick"
+      />
+    </template>
+  </a-sub-menu>
+</template>
+<script setup lang="ts">
+import MenuItem from './MenuItem.vue'
+import type { RouteModuleList } from '~/router/routes/typings'
+
+interface EmitEvents {
+  (e: 'handleClick', path: string): void
+}
+interface Props {
+  menu: GetArrayItemType<RouteModuleList>
+  parentPath: string
+  // 当前的深度，用于计算 key
+  currentDepth: number
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<EmitEvents>()
+
+function handleClick(path: string, depth = 1) {
+  emit('handleClick', depth > 1 ? `${props.parentPath}/${path}` : path)
+}
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import type { App } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { basicRoutes, asyncRoutes } from './routes'
 import { setupRouterGuard } from './guard'
+import { setupDynamicRoutes } from './routes/plugins/dynamicRoutes'
 
 export const router = createRouter({
   routes: [...basicRoutes, ...asyncRoutes],
@@ -15,4 +16,6 @@ export function setupRouter(app: App) {
 
   // Router guard
   setupRouterGuard(router)
+
+  setupDynamicRoutes(asyncRoutes)
 }

--- a/src/router/routes/index.ts
+++ b/src/router/routes/index.ts
@@ -1,4 +1,4 @@
-import { RouteModuleList } from './typings'
+import type { RouteModuleList } from './typings'
 
 export * from './basic'
 

--- a/src/router/routes/index.ts
+++ b/src/router/routes/index.ts
@@ -1,10 +1,10 @@
-import type { RouteRecordRaw } from 'vue-router'
+import { RouteModuleList } from './typings'
 
 export * from './basic'
 
 const modules = import.meta.globEager('./modules/**/*.ts')
 
-const routeModuleList: RouteRecordRaw[] = []
+const routeModuleList: RouteModuleList = []
 
 Object.keys(modules).forEach((key) => {
   const mod = modules[key].default || {}

--- a/src/router/routes/modules/about.ts
+++ b/src/router/routes/modules/about.ts
@@ -1,4 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
+import {
+  SettingOutlined
+} from '@ant-design/icons-vue'
 import { DefaultLayout } from '~/layouts'
 
 const route: RouteRecordRaw = {
@@ -6,6 +9,13 @@ const route: RouteRecordRaw = {
   name: 'about',
   component: DefaultLayout,
   redirect: '/about',
+  meta: {
+    title: '关于',
+    isMenu: true,
+    icon: SettingOutlined,
+    single: true,
+    sort: 3
+  },
   children: [
     {
       path: '',

--- a/src/router/routes/modules/about.ts
+++ b/src/router/routes/modules/about.ts
@@ -1,7 +1,5 @@
 import type { RouteRecordRaw } from 'vue-router'
-import {
-  SettingOutlined
-} from '@ant-design/icons-vue'
+import { SettingOutlined } from '@ant-design/icons-vue'
 import { DefaultLayout } from '~/layouts'
 
 const route: RouteRecordRaw = {

--- a/src/router/routes/modules/about.ts
+++ b/src/router/routes/modules/about.ts
@@ -9,7 +9,6 @@ const route: RouteRecordRaw = {
   redirect: '/about',
   meta: {
     title: '关于',
-    isMenu: true,
     icon: SettingOutlined,
     single: true,
     sort: 3

--- a/src/router/routes/modules/demo.ts
+++ b/src/router/routes/modules/demo.ts
@@ -11,7 +11,6 @@ const route: RouteRecordRaw = {
   redirect: '/demo/excel/import',
   meta: {
     title: 'Demo',
-    isMenu: true,
     icon: AppstoreOutlined,
     sort: 1
   },
@@ -22,7 +21,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/excel/import.vue'),
       meta: {
         title: 'Import Excel',
-        isMenu: true,
         sort: 1
       }
     },
@@ -32,7 +30,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/excel/export.vue'),
       meta: {
         title: 'Export Excel',
-        isMenu: true,
         sort: 2
       }
     },
@@ -42,7 +39,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/watermark/index.vue'),
       meta: {
         title: '水印',
-        isMenu: true,
         sort: 3
       }
     },
@@ -52,7 +48,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/count-to/index.vue'),
       meta: {
         title: 'CountTo',
-        isMenu: true,
         sort: 4
       }
     },
@@ -62,7 +57,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/rich-text/index.vue'),
       meta: {
         title: '富文本编辑器',
-        isMenu: true,
         sort: 5
       }
     },
@@ -72,7 +66,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/cropper/index.vue'),
       meta: {
         title: '图片裁剪',
-        isMenu: true,
         sort: 6
       }
     },
@@ -82,7 +75,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/md-editor/index.vue'),
       meta: {
         title: 'Markdown 编辑器',
-        isMenu: true,
         sort: 7
       }
     },
@@ -92,7 +84,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/demo/fullscreen/index.vue'),
       meta: {
         title: '全屏',
-        isMenu: true,
         sort: 8
       }
     },
@@ -102,7 +93,6 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/about/index.vue'),
       meta: {
         title: '测试二级菜单',
-        isMenu: true,
         sort: 9
       },
       children: [
@@ -112,7 +102,6 @@ const route: RouteRecordRaw = {
           component: () => import('~/views/about/index.vue'),
           meta: {
             title: '测试三级菜单',
-            isMenu: true,
             sort: 1
           },
           children: [
@@ -122,7 +111,6 @@ const route: RouteRecordRaw = {
               component: () => import('~/views/about/index.vue'),
               meta: {
                 title: '测试四级菜单',
-                isMenu: true,
                 sort: 1
               }
             }

--- a/src/router/routes/modules/demo.ts
+++ b/src/router/routes/modules/demo.ts
@@ -95,6 +95,40 @@ const route: RouteRecordRaw = {
         isMenu: true,
         sort: 8
       }
+    },
+    {
+      path: 'testLevel2',
+      name: 'testLevel2',
+      component: () => import('~/views/about/index.vue'),
+      meta: {
+        title: '测试二级菜单',
+        isMenu: true,
+        sort: 9
+      },
+      children: [
+        {
+          path: 'testLevel3',
+          name: 'testLevel3',
+          component: () => import('~/views/about/index.vue'),
+          meta: {
+            title: '测试三级菜单',
+            isMenu: true,
+            sort: 1
+          },
+          children: [
+            {
+              path: 'testLevel4',
+              name: 'testLevel4',
+              component: () => import('~/views/about/index.vue'),
+              meta: {
+                title: '测试四级菜单',
+                isMenu: true,
+                sort: 1
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/router/routes/modules/demo.ts
+++ b/src/router/routes/modules/demo.ts
@@ -1,4 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
+import {
+  AppstoreOutlined
+} from '@ant-design/icons-vue'
 import { DefaultLayout } from '~/layouts'
 
 const route: RouteRecordRaw = {
@@ -6,46 +9,92 @@ const route: RouteRecordRaw = {
   name: 'demo',
   component: DefaultLayout,
   redirect: '/demo/excel/import',
+  meta: {
+    title: 'Demo',
+    isMenu: true,
+    icon: AppstoreOutlined,
+    sort: 1
+  },
   children: [
     {
       path: 'excel/import',
       name: 'import-excel',
-      component: () => import('~/views/demo/excel/import.vue')
+      component: () => import('~/views/demo/excel/import.vue'),
+      meta: {
+        title: 'Import Excel',
+        isMenu: true,
+        sort: 1
+      }
     },
     {
       path: 'excel/export',
       name: 'export-excel',
-      component: () => import('~/views/demo/excel/export.vue')
+      component: () => import('~/views/demo/excel/export.vue'),
+      meta: {
+        title: 'Export Excel',
+        isMenu: true,
+        sort: 2
+      }
     },
     {
       path: 'watermark',
       name: 'watermark',
-      component: () => import('~/views/demo/watermark/index.vue')
+      component: () => import('~/views/demo/watermark/index.vue'),
+      meta: {
+        title: '水印',
+        isMenu: true,
+        sort: 3
+      }
     },
     {
       path: 'count-to',
       name: 'count-to',
-      component: () => import('~/views/demo/count-to/index.vue')
+      component: () => import('~/views/demo/count-to/index.vue'),
+      meta: {
+        title: 'CountTo',
+        isMenu: true,
+        sort: 4
+      }
     },
     {
       path: 'rich-text',
       name: 'rich-text',
-      component: () => import('~/views/demo/rich-text/index.vue')
+      component: () => import('~/views/demo/rich-text/index.vue'),
+      meta: {
+        title: '富文本编辑器',
+        isMenu: true,
+        sort: 5
+      }
     },
     {
       path: 'cropper',
       name: 'cropper',
-      component: () => import('~/views/demo/cropper/index.vue')
+      component: () => import('~/views/demo/cropper/index.vue'),
+      meta: {
+        title: '图片裁剪',
+        isMenu: true,
+        sort: 6
+      }
     },
     {
       path: 'md-editor',
       name: 'md-editor',
-      component: () => import('~/views/demo/md-editor/index.vue')
+      component: () => import('~/views/demo/md-editor/index.vue'),
+      meta: {
+        title: 'Markdown 编辑器',
+        isMenu: true,
+        sort: 7
+      }
     },
     {
       path: 'fullscreen',
       name: 'fullscreen',
-      component: () => import('~/views/demo/fullscreen/index.vue')
+      component: () => import('~/views/demo/fullscreen/index.vue'),
+      meta: {
+        title: '全屏',
+        isMenu: true,
+        sort: 8
+      }
     }
   ]
 }

--- a/src/router/routes/modules/page.ts
+++ b/src/router/routes/modules/page.ts
@@ -11,7 +11,6 @@ const route: RouteRecordRaw = {
   redirect: '/page/404',
   meta: {
     title: '页面',
-    isMenu: true,
     icon: ChromeOutlined,
     sort: 2
   },
@@ -22,8 +21,17 @@ const route: RouteRecordRaw = {
       component: () => import('~/views/page/not-found/index.vue'),
       meta: {
         title: '404 页面',
-        isMenu: true,
         sort: 1
+      }
+    },
+    {
+      path: 'testHide',
+      name: 'testHide',
+      component: () => import('~/views/about/index.vue'),
+      meta: {
+        title: '测试隐藏菜单',
+        sort: 2,
+        isHide: true
       }
     }
   ]

--- a/src/router/routes/modules/page.ts
+++ b/src/router/routes/modules/page.ts
@@ -1,4 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
+import {
+  ChromeOutlined
+} from '@ant-design/icons-vue'
 import { DefaultLayout } from '~/layouts'
 
 const route: RouteRecordRaw = {
@@ -6,11 +9,22 @@ const route: RouteRecordRaw = {
   name: 'page',
   component: DefaultLayout,
   redirect: '/page/404',
+  meta: {
+    title: '页面',
+    isMenu: true,
+    icon: ChromeOutlined,
+    sort: 2
+  },
   children: [
     {
       path: '404',
       name: '404',
-      component: () => import('~/views/page/not-found/index.vue')
+      component: () => import('~/views/page/not-found/index.vue'),
+      meta: {
+        title: '404 页面',
+        isMenu: true,
+        sort: 1
+      }
     }
   ]
 }

--- a/src/router/routes/plugins/dynamicRoutes.ts
+++ b/src/router/routes/plugins/dynamicRoutes.ts
@@ -1,0 +1,25 @@
+import type { RouteModuleList } from '../typings'
+import { useRouteStore } from '~/stores'
+
+type RouteModule = GetArrayItemType<RouteModuleList>
+
+function sortBySortKey(routerModuleList: RouteModuleList | RouteModule['children']) {
+  return routerModuleList.sort((a: RouteModule, b: RouteModule) => a.meta!.sort - b.meta!.sort)
+}
+
+function sortRoutesBySortKey(routerModuleList: RouteModuleList) {
+  for (const routerModule of routerModuleList) {
+    const single = routerModule.meta?.single || false
+    if (!single) routerModule.children = sortBySortKey(routerModule.children)
+  }
+  return sortBySortKey(routerModuleList)
+}
+
+/**
+ * 用于将本地静态路由 push 到路由表中
+ * @param routerModuleList 路由
+ */
+export function setupDynamicRoutes(routerModuleList: RouteModuleList) {
+  const store = useRouteStore()
+  store.appendRoute(sortRoutesBySortKey(routerModuleList))
+}

--- a/src/router/routes/plugins/dynamicRoutes.ts
+++ b/src/router/routes/plugins/dynamicRoutes.ts
@@ -15,11 +15,29 @@ function sortRoutesBySortKey(routerModuleList: RouteModuleList) {
   return sortBySortKey(routerModuleList)
 }
 
+function filterHideRoute(routerModuleList: RouteModuleList | RouteModule['children']) {
+  if (!routerModuleList) return []
+  const filteredModuleList = []
+  // for 循环提高执行效率
+  for (let i = 0; i < routerModuleList.length; i++) {
+    const routeModule = routerModuleList[i]
+    if (routeModule.meta?.isHide) continue
+    let { children } = routeModule
+    if (children && children.length) {
+      children = routeModule.children = filterHideRoute(routeModule.children)
+      // 如果筛选出来子级没有需要展示的，那么就把 children 这个属性删除掉
+      if (!children.length) Reflect.deleteProperty(routeModule, 'children')
+    }
+    filteredModuleList.push(routeModule)
+  }
+  return filteredModuleList
+}
+
 /**
  * 用于将本地静态路由 push 到路由表中
  * @param routerModuleList 路由
  */
 export function setupDynamicRoutes(routerModuleList: RouteModuleList) {
   const store = useRouteStore()
-  store.appendRoute(sortRoutesBySortKey(routerModuleList))
+  store.appendRoute(sortRoutesBySortKey(filterHideRoute(routerModuleList)))
 }

--- a/src/router/routes/typings.ts
+++ b/src/router/routes/typings.ts
@@ -1,3 +1,3 @@
-import type { RouteRecordRaw } from "vue-router";
+import type { RouteRecordRaw } from 'vue-router'
 
 export type RouteModuleList = RouteRecordRaw[]

--- a/src/router/routes/typings.ts
+++ b/src/router/routes/typings.ts
@@ -1,0 +1,3 @@
+import type { RouteRecordRaw } from "vue-router";
+
+export type RouteModuleList = RouteRecordRaw[]

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -6,3 +6,5 @@ const store = createPinia()
 export function setupStore(app: App<Element>) {
   app.use(store)
 }
+
+export * from './modules'

--- a/src/stores/modules/index.ts
+++ b/src/stores/modules/index.ts
@@ -1,0 +1,2 @@
+export * from './routes'
+export * from './user'

--- a/src/stores/modules/routes.ts
+++ b/src/stores/modules/routes.ts
@@ -1,0 +1,23 @@
+import { defineStore } from 'pinia'
+import type { RouteModuleList } from '~/router/routes/typings'
+
+interface RouteState {
+  routes: RouteModuleList
+}
+
+export const useRouteStore = defineStore('user', {
+  state: (): RouteState => ({
+    routes: []
+  }),
+  getters: {
+    getRoutes: (state) => {
+      return state.routes
+    }
+  },
+  actions: {
+    appendRoute(route: GetArrayItemType<RouteModuleList> | RouteModuleList): void {
+      if (Array.isArray(route)) { this.routes.push(...route) }
+      else { this.routes.push(route) }
+    }
+  }
+})

--- a/src/stores/modules/routes.ts
+++ b/src/stores/modules/routes.ts
@@ -5,7 +5,7 @@ interface RouteState {
   routes: RouteModuleList
 }
 
-export const useRouteStore = defineStore('user', {
+export const useRouteStore = defineStore('routes', {
   state: (): RouteState => ({
     routes: []
   }),

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,4 +2,6 @@ declare interface Fn<T = any, R = T> {
   (...arg: T[]): R
 }
 
+declare type GetArrayItemType<T extends unknown[]> = T extends S[] ? S : never
+
 declare type TargetContext = '_self' | '_blank'

--- a/types/routes.d.ts
+++ b/types/routes.d.ts
@@ -2,16 +2,16 @@ import 'vue-router'
 import type { FunctionalComponent } from 'vue'
 
 declare module 'vue-router' {
-    interface RouteMeta {
-        // 标题
-        title: string
-        // 是否是菜单
-        isMenu: boolean
-        // icon
-        icon?: FunctionalComponent
-        // 是否是单独的菜单
-        single?: boolean,
-        // 排序索引
-        sort: number
-    }
+  interface RouteMeta {
+    // 标题
+    title: string
+    // 是否是菜单
+    isMenu: boolean
+    // icon
+    icon?: FunctionalComponent
+    // 是否是单独的菜单
+    single?: boolean
+    // 排序索引
+    sort: number
+  }
 }

--- a/types/routes.d.ts
+++ b/types/routes.d.ts
@@ -5,11 +5,11 @@ declare module 'vue-router' {
   interface RouteMeta {
     // 标题
     title: string
-    // 是否是菜单
-    isMenu: boolean
     // 排序索引
     sort: number
-    // icon
+    // 是否隐藏菜单
+    isHide?: boolean
+    // icon，目前仅支持引入 antdv 中的 icon 组件
     icon?: FunctionalComponent
     // 是否是单独的菜单
     single?: boolean

--- a/types/routes.d.ts
+++ b/types/routes.d.ts
@@ -1,0 +1,17 @@
+import 'vue-router'
+import type { FunctionalComponent } from 'vue'
+
+declare module 'vue-router' {
+    interface RouteMeta {
+        // 标题
+        title: string
+        // 是否是菜单
+        isMenu: boolean
+        // icon
+        icon?: FunctionalComponent
+        // 是否是单独的菜单
+        single?: boolean,
+        // 排序索引
+        sort: number
+    }
+}

--- a/types/routes.d.ts
+++ b/types/routes.d.ts
@@ -7,11 +7,11 @@ declare module 'vue-router' {
     title: string
     // 是否是菜单
     isMenu: boolean
+    // 排序索引
+    sort: number
     // icon
     icon?: FunctionalComponent
     // 是否是单独的菜单
     single?: boolean
-    // 排序索引
-    sort: number
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

# About This PR

close #51 

目前已实现动态读取 `routes/modules/xx.ts` 中的路由，并自动渲染视图

## feat

```ts
interface RouteMeta {
    // 标题
    title: string
    // 是否是菜单
    isMenu: boolean
    // icon
    icon?: FunctionalComponent
    // 是否是单独的菜单
    single?: boolean
    // 排序索引
    sort: number
  }
```
以上内容需要放在 route 定义的 meta 字段中，例如

```ts
{
    path: 'fullscreen',
    name: 'fullscreen',
    component: () => import('~/views/demo/fullscreen/index.vue'),
    meta: {
      title: '全屏',
      isMenu: true,
      sort: 8
    }
}
```

根据 children 自动适配多级菜单，若子 route 有 children，那么说明该路由是一个父级菜单，可展开。
理论上可以自动适配任意多级的菜单

## 实现原理

读取 routes，并 v-for 渲染，因此一定要配置好 `meta` 字段中的内容

关于文档，将会在 merge 后去改

自动适配多级菜单的原理就是写了两个组件，一个是单独的，一个是含有子级的，根据其 children 递归渲染

修改较多，review 可能比较困难，辛苦大家了！
